### PR TITLE
Support password and exclude-old-transactions

### DIFF
--- a/lib/Web/MarketReceipt/Verifier/AppStore.pm
+++ b/lib/Web/MarketReceipt/Verifier/AppStore.pm
@@ -18,10 +18,18 @@ sub verify {
 
     my $environment = 'Production';
     my $receipt = $args{receipt};
+    my $password = $args{password};
+    my $exclude_old_transactions = $args{exclude_old_transactions};
 
     my $hash = {
         'receipt-data' => $receipt,
     };
+    if ($password) {
+        $hash->{password} = $password;
+    }
+    if ($exclude_old_transactions) {
+        $hash->{'exclude-old-transactions'} = \1;
+    }
 
     # try production environment first. cf.
     #   https://developer.apple.com/library/ios/technotes/tn2259/_index.html FAQ16


### PR DESCRIPTION
I added abilities to send `password` and `exclude-old-transactions` to AppStore.
Our use-case needs these parameters.

see also: [Validating Receipts With the App Store](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html#//apple_ref/doc/uid/TP40010573-CH104-SW1)