### PR TITLE
Web::MarketReceipt::Verifier::Mock::AppStore

### DIFF
--- a/lib/Web/MarketReceipt/Verifier/Mock/AppStore.pm
+++ b/lib/Web/MarketReceipt/Verifier/Mock/AppStore.pm
@@ -78,7 +78,7 @@ sub _parse_oldstlye_plist {
 
     my $data = decode_base64($text);
     my ($properties_str) = $data =~ /{(.*)}/s;
-    my %kv = $properties_str =~ /\s*"(\S+)"\s*=\s*"(.+)";/g;
+    my %kv = $properties_str =~ /\s*"(.*?)"\s*=\s*"(.*?)"\s*;/msg;
 
     return \%kv;
 }

--- a/lib/Web/MarketReceipt/Verifier/Mock/AppStore.pm
+++ b/lib/Web/MarketReceipt/Verifier/Mock/AppStore.pm
@@ -1,0 +1,122 @@
+package Web::MarketReceipt::Verifier::Mock::AppStore;
+use Mouse;
+use utf8;
+
+extends 'Web::MarketReceipt::Verifier';
+
+use Web::MarketReceipt;
+use MIME::Base64 qw/decode_base64/;
+
+has verifier => (
+    is      => 'ro',
+    isa     => 'CodeRef',
+    default => sub {
+        my $self = shift;
+
+        return sub { $self->_default_verifier(@_) };
+    },
+    lazy    => 1,
+);
+
+no Mouse;
+
+sub _default_verifier {
+    my ($self, %args) = @_;
+
+    my $receipt = $args{receipt};
+
+    my $parsed = $self->_parse_receipt($receipt);
+
+    my $purchase_info = $parsed->{'purchase-info'};
+    my %underscored = (
+        map {
+            my $key = $_;
+            ($key =~ s/-/_/gr) => $purchase_info->{$key}
+        } keys %$purchase_info
+    );
+    my $environment = $parsed->{environment} // 'Production';
+
+    my $result = Web::MarketReceipt->new(
+        is_success => 1,
+        store      => 'AppStore',
+        raw        => \%underscored,
+        orders     => [
+            {
+                product_identifier => $underscored{product_id},
+                unique_identifier  => 'AppStore:' . $underscored{original_transaction_id},
+                purchased_epoch    => $underscored{original_purchase_date_ms},
+                quantity           => $underscored{quantity},
+                environment        => $environment,
+                state              => 'purchased',
+            }
+        ],
+    );
+
+    return $result;
+}
+
+sub verify {
+    my $self = shift;
+
+    return $self->verifier->(@_);
+}
+
+sub _parse_receipt {
+    my ($class, $receipt) = @_;
+
+    my $data = $class->_parse_oldstlye_plist($receipt);
+    my $purchase_info = $class->_parse_oldstlye_plist($data->{'purchase-info'});
+    $data->{'purchase-info'} = $purchase_info;
+
+    return $data;
+}
+
+sub _parse_oldstlye_plist {
+    my ($class, $text) = @_;
+
+    my $data = decode_base64($text);
+    my ($properties_str) = $data =~ /{(.*)}/s;
+    my %kv = $properties_str =~ /\s*"(\S+)"\s*=\s*"(\S+)";/g;
+
+    return \%kv;
+}
+
+1;
+
+__END__
+
+Web::MarketReceipt::Verifier::Mock::AppStore - The mocking class for test of using Web::MarketReceipt::Verifier::AppStore
+
+=head1 SYNOPSIS
+
+    use Test::More;
+    use Web::MarketReceipt::Verifier::Mock::AppStore;
+
+    my $shop = MyGame::Shop->new(
+        appstore_verifier => Web::MarketReceipt::Verifier::Mock::AppStore->new,
+    );
+
+    # MyApp::Game#purchase_by_appstore grant to user by receipt from AppStore.
+    my $result = $shop->purchase_by_appstore(receipt => $receipt_text);
+
+    is $result->received_items, $expected;
+
+
+=head1 DESCRIPTION
+
+Web::MarketReceipt::Verifier::Mock::AppStore is mock like Web::MarketReceipt::Verifier::AppStore.
+
+This module without to send request to Apple's validation server.
+
+=head1 LICENSE
+
+Copyright (C) KAYAC Inc.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 AUTHOR
+
+macopy <macopy123@gmail.com>
+
+=cut

--- a/lib/Web/MarketReceipt/Verifier/Mock/AppStore.pm
+++ b/lib/Web/MarketReceipt/Verifier/Mock/AppStore.pm
@@ -73,6 +73,8 @@ sub _parse_receipt {
     return $data;
 }
 
+# XXX: This parser is poor but I look work with a receipt from appstore.
+# If that do not parse at your receipt, please report issues or pull requests.
 sub _parse_oldstlye_plist {
     my ($class, $text) = @_;
 

--- a/lib/Web/MarketReceipt/Verifier/Mock/AppStore.pm
+++ b/lib/Web/MarketReceipt/Verifier/Mock/AppStore.pm
@@ -31,10 +31,12 @@ sub _default_verifier {
     my %underscored = (
         map {
             my $key = $_;
-            ($key =~ s/-/_/gr) => $purchase_info->{$key}
+            $key =~ s/-/_/g;
+            $key => $purchase_info->{$_}
         } keys %$purchase_info
     );
-    my $environment = $parsed->{environment} // 'Production';
+    my $environment = exists $parsed->{environment} ?
+        $parsed->{environment} : 'Production';
 
     my $result = Web::MarketReceipt->new(
         is_success => 1,

--- a/lib/Web/MarketReceipt/Verifier/Mock/AppStore.pm
+++ b/lib/Web/MarketReceipt/Verifier/Mock/AppStore.pm
@@ -78,7 +78,7 @@ sub _parse_oldstlye_plist {
 
     my $data = decode_base64($text);
     my ($properties_str) = $data =~ /{(.*)}/s;
-    my %kv = $properties_str =~ /\s*"(\S+)"\s*=\s*"(\S+)";/g;
+    my %kv = $properties_str =~ /\s*"(\S+)"\s*=\s*"(.+)";/g;
 
     return \%kv;
 }

--- a/t/03_verify_mock_appstore.t
+++ b/t/03_verify_mock_appstore.t
@@ -1,0 +1,66 @@
+use strict;
+use Test::More;
+use MIME::Base64 qw/encode_base64/;
+use Web::MarketReceipt::Verifier::Mock::AppStore;
+
+my $purchase_info = encode_base64('
+{
+	"original-purchase-date-pst" = "2000-01-01 00:00:00 America/Los_Angeles";
+	"unique-identifier" = "ffffffffffffffffffffffffffffffffffffffff";
+	"original-transaction-id" = "9999999999999999";
+	"bvrs" = "1.0";
+	"transaction-id" = "9999999999999999";
+	"quantity" = "1";
+	"original-purchase-date-ms" = "946713600000";
+	"product-id" = "com.example.001";
+	"item-id" = "999999999";
+	"bid" = "com.example.001";
+	"purchase-date-ms" = "946713600000";
+	"purchase-date" = "2000-01-01 17:00:00 Etc/GMT";
+	"purchase-date-pst" = "2000-01-01 00:00:00 America/Los_Angeles";
+	"original-purchase-date" = "2000-01-01 17:00:00 Etc/GMT";
+}', '');
+my $receipt_text = encode_base64('
+{
+	"signature" = "XXXXXX";
+	"purchase-info" = "' . $purchase_info . '";
+	"environment" = "Sandbox";
+	"pod" = "100";
+	"signing-status" = "0";
+}
+', '');
+
+subtest 'verify' => sub {
+    my $receipt = Web::MarketReceipt::Verifier::Mock::AppStore->new->verify(
+        receipt => $receipt_text,
+    );
+
+    ok $receipt->is_success;
+    is_deeply $receipt->raw, {
+        "original_purchase_date_pst" => "2000-01-01 00:00:00 America/Los_Angeles",
+        "unique_identifier"          => "ffffffffffffffffffffffffffffffffffffffff",
+        "original_transaction_id"    => "9999999999999999",
+        "bvrs"                       => "1.0",
+        "transaction_id"             => "9999999999999999",
+        "quantity"                   => "1",
+        "original_purchase_date_ms"  => "946713600000",
+        "product_id"                 => "com.example.001",
+        "item_id"                    => "999999999",
+        "bid"                        => "com.example.001",
+        "purchase_date_ms"           => "946713600000",
+        "purchase_date"              => "2000-01-01 17:00:00 Etc/GMT",
+        "purchase_date_pst"          => "2000-01-01 00:00:00 America/Los_Angeles",
+        "original_purchase_date"     => "2000-01-01 17:00:00 Etc/GMT",
+    };
+
+    my $order = $receipt->orders->[0];
+
+    is $order->product_identifier, "com.example.001";
+    is $order->unique_identifier, "AppStore:9999999999999999";
+    is $order->purchased_epoch, "946713600000";
+    is $order->quantity, "1";
+    is $order->environment, "Sandbox";
+    is $order->state, "purchased";
+};
+
+done_testing;


### PR DESCRIPTION
レシート検証を含むモジュールのテストでアップルの検証サーバに依存したくないので、
通信を行わずに検証を行うテスト用モジュールを作りました。