### PR TITLE
Add Google Play purchase state "pending"

### DIFF
--- a/lib/Web/MarketReceipt/Verifier/GooglePlay.pm
+++ b/lib/Web/MarketReceipt/Verifier/GooglePlay.pm
@@ -73,6 +73,8 @@ sub _purchase_state {
         return 'refunded';
     } elsif ($purchase_state == 3) {
         return 'expired';
+    } elsif ($purchase_state == 4) {
+        return 'pending';
     }
 
     croak sprintf 'invalid purchase state: %s', $purchase_state;


### PR DESCRIPTION
Google Playでコンビニ決済ができるようになり、GooglePurchaseStateにPending(4)が追加されたようです
https://developer.android.com/google/play/billing/integrate#pending

Web::MarketReceipt::Verifier::GooglePlay->_purchase_stateが未対応でエラーとなるため、purchase_state: 4を追加しました
https://kabatin.hateblo.jp/entry/2021/11/18/123148



