### PR TITLE
Add "pending" to enum "OrderState"

### DIFF
--- a/lib/Web/MarketReceipt/Order.pm
+++ b/lib/Web/MarketReceipt/Order.pm
@@ -3,7 +3,7 @@ use Mouse;
 use Mouse::Util::TypeConstraints;
 use utf8;
 
-enum 'OrderState'       => qw/purchased canceled refunded expired/;
+enum 'OrderState'       => qw/purchased canceled refunded expired pending/;
 enum 'OrderEnvironment' => qw/Sandbox Production/;
 
 has product_identifier => (

--- a/lib/Web/MarketReceipt/Verifier/GooglePlay.pm
+++ b/lib/Web/MarketReceipt/Verifier/GooglePlay.pm
@@ -10,6 +10,8 @@ use Crypt::OpenSSL::RSA;
 use MIME::Base64;
 use JSON::XS;
 
+use Web::MarketReceipt::Order;
+
 subtype 'Crypt::OpenSSL::RSA' => as 'Object' => where { $_->isa('Crypt::OpenSSL::RSA') };
 coerce  'Crypt::OpenSSL::RSA'
     => from 'Str',
@@ -65,15 +67,15 @@ sub _order2hash {
 sub _purchase_state {
     my ($self, $purchase_state) = @_;
 
-    if ($purchase_state == 0) {
+    if ($purchase_state == OrderState.purchased) {
         return 'purchased';
-    } elsif ($purchase_state == 1) {
+    } elsif ($purchase_state == OrderState.canceled) {
         return 'canceled';
-    } elsif ($purchase_state == 2) {
+    } elsif ($purchase_state == OrderState.refunded) {
         return 'refunded';
-    } elsif ($purchase_state == 3) {
+    } elsif ($purchase_state == OrderState.expired) {
         return 'expired';
-    } elsif ($purchase_state == 4) {
+    } elsif ($purchase_state == OrderState.pending) {
         return 'pending';
     }
 

--- a/lib/Web/MarketReceipt/Verifier/GooglePlay.pm
+++ b/lib/Web/MarketReceipt/Verifier/GooglePlay.pm
@@ -65,7 +65,7 @@ sub _order2hash {
 sub _purchase_state {
     my ($self, $purchase_state) = @_;
 
-    # Web::MarketReceipt::OrderモジュールのOrderStateにも追加が必要
+    # REMIND: if you want to add state to these, you must be added to Web::MarketReceipt::Order#OrderState
     if ($purchase_state == 0) {
         return 'purchased';
     } elsif ($purchase_state == 1) {

--- a/lib/Web/MarketReceipt/Verifier/GooglePlay.pm
+++ b/lib/Web/MarketReceipt/Verifier/GooglePlay.pm
@@ -10,8 +10,6 @@ use Crypt::OpenSSL::RSA;
 use MIME::Base64;
 use JSON::XS;
 
-use Web::MarketReceipt::Order;
-
 subtype 'Crypt::OpenSSL::RSA' => as 'Object' => where { $_->isa('Crypt::OpenSSL::RSA') };
 coerce  'Crypt::OpenSSL::RSA'
     => from 'Str',
@@ -67,15 +65,16 @@ sub _order2hash {
 sub _purchase_state {
     my ($self, $purchase_state) = @_;
 
-    if ($purchase_state == OrderState.purchased) {
+    # Web::MarketReceipt::OrderモジュールのOrderStateにも追加が必要
+    if ($purchase_state == 0) {
         return 'purchased';
-    } elsif ($purchase_state == OrderState.canceled) {
+    } elsif ($purchase_state == 1) {
         return 'canceled';
-    } elsif ($purchase_state == OrderState.refunded) {
+    } elsif ($purchase_state == 2) {
         return 'refunded';
-    } elsif ($purchase_state == OrderState.expired) {
+    } elsif ($purchase_state == 3) {
         return 'expired';
-    } elsif ($purchase_state == OrderState.pending) {
+    } elsif ($purchase_state == 4) {
         return 'pending';
     }
 

--- a/t/02_verify_google_play.t
+++ b/t/02_verify_google_play.t
@@ -18,7 +18,7 @@ subtest 'api version v2 format' => sub {
 
     my $signed_data = {
         orders => [{
-            purchaseState => 0,
+            purchaseState => 4,
             productId     => '12345abcd',
             orderId       => 'abcdefg12345',
             purchaseTime  => 12345678,
@@ -37,6 +37,7 @@ subtest 'api version v2 format' => sub {
     isa_ok $result, 'Web::MarketReceipt';
     ok $result->is_success;
     is scalar @{$result->orders}, 1;
+    is $result->orders->[0]->state, 'pending';
     is $result->orders->[0]->product_identifier, '12345abcd';
     is $result->orders->[0]->unique_identifier, 'GooglePlay:' . 'abcdefg12345';
 };
@@ -69,6 +70,7 @@ subtest 'api version v3 format' => sub {
     isa_ok $result, 'Web::MarketReceipt';
     ok $result->is_success;
     is scalar @{$result->orders}, 1;
+    is $result->orders->[0]->state, 'purchased';
     is $result->orders->[0]->product_identifier, '12345abcd';
     is $result->orders->[0]->unique_identifier, 'GooglePlay:' . 'abcdefg12345';
 };


### PR DESCRIPTION
[こちら](https://github.com/kayac/p5-Web-MarketReceipt/pull/6) で対応したGoogle Playでコンビニ決済対応で追加したpurchase_state:4(pending) の対応で、enumで定義されているOrderStateにも追加が必要だったため対応しました。

